### PR TITLE
Use a maybe CE to simplify null navigation

### DIFF
--- a/Builders.fs
+++ b/Builders.fs
@@ -1,0 +1,67 @@
+namespace DalamudPluginProjectTemplateFSharp
+
+[<AutoOpen>]
+module internal Builders =
+    open System
+
+    //#region Public domain code from FSharpx.Extras' Option.fs
+    type MaybeBuilder() =
+        member _.Return(x) = Some x
+
+        member _.ReturnFrom(m: 'T option) = m
+
+        member _.Bind(m, f) = Option.bind f m
+
+        member _.Zero() = None
+
+        member _.Combine(m, f) = Option.bind f m
+
+        member _.Delay(f: unit -> _) = f
+
+        member _.Run(f) = f ()
+
+        member this.TryWith(m, h) =
+            try
+                this.ReturnFrom(m)
+            with
+            | e -> h e
+
+        member this.TryFinally(m, compensation) =
+            try
+                this.ReturnFrom(m)
+            finally
+                compensation ()
+
+        member this.Using(res: #IDisposable, body) =
+            this.TryFinally(
+                body res,
+                (fun () ->
+                    if not (isNull (box res)) then
+                        res.Dispose())
+            )
+
+        member this.While(guard, f) =
+            if not (guard ()) then
+                Some()
+            else
+                do f () |> ignore
+                this.While(guard, f)
+
+        member this.For(sequence: seq<_>, body) =
+            this.Using(
+                sequence.GetEnumerator(),
+                fun enum -> this.While(enum.MoveNext, this.Delay(fun () -> body enum.Current))
+            )
+    //#endregion
+
+    /// The maybe monad defined on 'T option.
+    /// Has extensions to support binding to non-Option values that still have Option-like semantics,
+    /// like nullable values and references.
+    let maybe = MaybeBuilder()
+
+    // extensions to make it more ergonomic to bind to not-Option values
+    type MaybeBuilder with
+        // overload to transparently handle "let! foo = nullable ref"
+        member _.Bind(m, f) = Option.bind f (Option.ofObj m)
+        // overload to transparently handle "let! foo = nullable val"
+        member _.Bind(m, f) = Option.bind f (Option.ofNullable m)

--- a/DalamudPluginProjectTemplateFSharp.fsproj
+++ b/DalamudPluginProjectTemplateFSharp.fsproj
@@ -6,23 +6,28 @@
 		<PlatformTarget>x64</PlatformTarget>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="README.md" />
+		<Compile Include="Builders.fs" />
 		<Compile Include="Attributes\HelpMessageAttribute.fs" />
 		<Compile Include="Attributes\DoNotShowInHelpAttribute.fs" />
 		<Compile Include="Attributes\CommandAttribute.fs" />
 		<Compile Include="Attributes\AliasesAttribute.fs" />
 		<Content Include="DalamudPluginProjectTemplateFSharp.json" />
+		<!-- Add extra files past this point (order is important in F#) -->
 		<Compile Include="PluginCommandManager.fs" />
 		<Compile Include="PluginUI.fs" />
 		<Compile Include="Configuration.fs" />
+		<!-- Plugin.fs should be last -->
 		<Compile Include="Plugin.fs" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="DalamudPackager" Version="2.1.2" />
+		<PackageReference Update="FSharp.Core" Version="6.0.3" />
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -61,10 +66,6 @@
 			<HintPath>$(DalamudLibPath)\Newtonsoft.Json.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="6.0.3" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Copy the MaybeBuilder from FSharpx.Extras and augment it with support for null references and Nullable values.

Only the builder itself is used so a source code copy was preferred to bringing in an entire nuget package.

Also fixes the build output not copying FSharp.Core.dll, a necessary dependency.